### PR TITLE
Fix missing PricingPlans module

### DIFF
--- a/components/dashboard/pricing-plans.tsx
+++ b/components/dashboard/pricing-plans.tsx
@@ -1,0 +1,7 @@
+import { PricingSection } from "@/components/landing/pricing-section"
+
+export function PricingPlans() {
+  return <PricingSection />
+}
+
+export default PricingPlans


### PR DESCRIPTION
## Summary
- create `components/dashboard/pricing-plans.tsx` to satisfy imports on the subscription page

## Testing
- `pnpm build` *(fails: Environment variable missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b4dbaf228832086aa8c9bee183043