### PR TITLE
Fix dynamic route error for user limits API

### DIFF
--- a/app/api/user/limits/route.ts
+++ b/app/api/user/limits/route.ts
@@ -1,4 +1,9 @@
 import { NextResponse } from "next/server"
+
+// This API route relies on request headers for authentication and cannot be
+// statically optimized. Mark it as dynamic so Next.js always executes it on
+// the server.
+export const dynamic = "force-dynamic"
 import { getServerSession } from "next-auth/next"
 import { authOptions } from "@/app/api/auth/[...nextauth]/route"
 import { checkUserLimits, assignFreePlanToUser } from "@/lib/usage-limits"


### PR DESCRIPTION
## Summary
- mark `/api/user/limits` route as `force-dynamic`

## Testing
- `npm run lint` *(fails: requires interactive setup)*
- `npm run build` *(fails: missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_684b59844ed08320a49db88a7bfd50b6