### PR TITLE
Add telemetry for dashboard errors

### DIFF
--- a/app/(dashboard)/error.tsx
+++ b/app/(dashboard)/error.tsx
@@ -16,6 +16,16 @@ export default function DashboardError({
   useEffect(() => {
     // Log the error to an error reporting service
     console.error("Dashboard error:", error)
+    fetch("/api/telemetry/error", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message: error.message,
+        digest: error.digest,
+        stack: error.stack,
+        path: window.location.pathname,
+      }),
+    }).catch((e) => console.error("Telemetry send failed", e))
   }, [error])
 
   return (

--- a/app/api/telemetry/error/route.ts
+++ b/app/api/telemetry/error/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server"
+
+export async function POST(req: NextRequest) {
+  try {
+    const data = await req.json()
+    console.error("Dashboard telemetry error:", data)
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    console.error("Error processing telemetry:", err)
+    return NextResponse.json({ error: "Failed" }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- send dashboard error information to a new API route
- log posted error details on the server

## Testing
- `npm run lint` *(fails: Next.js not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b8ba81bdc8320a7f00dfe9c271d8d