### PR TITLE
Improve backend API error handling

### DIFF
--- a/app/api/v1/chatbots/[id]/chat/route.ts
+++ b/app/api/v1/chatbots/[id]/chat/route.ts
@@ -24,7 +24,19 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
     const chatbotId = params.id
 
     // Conectar ao banco de dados
-    const sql = neon(process.env.DATABASE_URL!)
+    const connectionString = process.env.DATABASE_URL
+    if (!connectionString) {
+      console.error("DATABASE_URL is not defined")
+      return new Response(
+        JSON.stringify({ error: "DATABASE_URL not configured" }),
+        {
+          status: 500,
+          headers: { "Content-Type": "application/json", ...corsHeaders },
+        },
+      )
+    }
+
+    const sql = neon(connectionString)
 
     // Buscar o chatbot
     const chatbots = await sql`
@@ -185,7 +197,9 @@ If you don't know the answer, say so politely.`
     })
   } catch (error) {
     console.error("Erro ao processar requisição:", error)
-    return new Response(JSON.stringify({ error: "Failed to generate response" }), {
+    const message =
+      error instanceof Error ? error.message : "Failed to generate response"
+    return new Response(JSON.stringify({ error: message }), {
       status: 500,
       headers: {
         "Content-Type": "application/json",

--- a/app/api/widget/[id]/route.ts
+++ b/app/api/widget/[id]/route.ts
@@ -22,8 +22,12 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
     const chatbotName = chatbotData.name || "Assistente"
     const chatbotImageUrl = chatbotData.imageUrl || ""
 
-    // URL base correta da aplicação
-    const baseUrl = "https://v0-chatbot-ai-kf.vercel.app"
+    // Determine the base URL dynamically to avoid hard coded environments
+    const baseUrl =
+      process.env.NEXT_PUBLIC_APP_URL ||
+      process.env.NEXTAUTH_URL ||
+      request.headers.get("origin") ||
+      ""
 
     // Gerar o script do widget
     const widgetScript = `


### PR DESCRIPTION
## Summary
- adjust chat endpoint to handle missing database URL and send explicit error messages
- use dynamic base URL in widget script for more flexible deployments

## Testing
- `npx tsc --noEmit` *(fails: Property errors, missing modules)*
- `npm run lint` *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_684f6746efe48320b59531428e6dee05