### PR TITLE
Fix My Chatbots page refresh after new bot creation

### DIFF
--- a/app/api/chatbots/route.ts
+++ b/app/api/chatbots/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth/next"
 import { sql } from "@/lib/db"
 import { authOptions } from "@/app/api/auth/[...nextauth]/route"
 import { getToken } from "next-auth/jwt"
+import { revalidatePath } from "next/cache"
 
 export async function GET(req: NextRequest) {
   try {
@@ -159,6 +160,13 @@ export async function POST(req: NextRequest) {
       `
 
       console.log("Verification query result:", verifyResult)
+
+      // Revalidate the dashboard chatbots page so the new bot appears immediately
+      try {
+        revalidatePath("/dashboard/chatbots")
+      } catch (revalidateError) {
+        console.error("Failed to revalidate /dashboard/chatbots:", revalidateError)
+      }
 
       return NextResponse.json(result[0])
     } catch (dbError) {


### PR DESCRIPTION
## Summary
- ensure /api/chatbots POST revalidates /dashboard/chatbots so the list updates

## Testing
- `npm run lint` *(fails: next not found)*
- `pnpm install` *(fails: postinstall prisma generate error)*

------
https://chatgpt.com/codex/tasks/task_e_684f873b98fc83208a5d5c16a17afbfd